### PR TITLE
Added word-break for .caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,7 @@
         margin: 0;
         padding: 0.4em;
         transition: background-color 100ms linear;
+        word-break: break-word;
       }
 
       .caption-text {


### PR DESCRIPTION
Huge subtitles overflow .captions container. It becomes shifted after this part of subtitles gets loaded and continues for the rest of the video. Please check the attached subtitle file (had to zip it since Github doesn't accept .srt) after `6:40`. `word-break` doesn't seem to _break_ anything else, since we are already in a no-space language. Setting `overflow-x` would be another option to fix the issue.
Noticed for the second time already, and I can't say I've seen a lot of them.
![image](https://user-images.githubusercontent.com/34808650/147960895-70031ea0-036e-4698-b842-6162121b25bf.png)
![image](https://user-images.githubusercontent.com/34808650/147960936-d4941740-c5ed-4333-a9ab-aa39cf37de4a.png)
[[Sakurato] Shiroi Suna no Aquatope [24][HEVC-10bit 1080p AAC][CHS&CHT&JPN].zip](https://github.com/animebook/animebook.github.io/files/7803221/Sakurato.Shiroi.Suna.no.Aquatope.24.HEVC-10bit.1080p.AAC.CHS.CHT.JPN.zip)

