### PR TITLE
Strip HTML from .srt captions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2196,6 +2196,11 @@
               );
             };
 
+            var strip = function (html) {
+              var doc = new DOMParser().parseFromString(html, 'text/html');
+              return doc.body.textContent || "";
+            }
+
             var entries = text.split(/\n[\n]+(?=[0-9]+\n)/g);
             var captions = entries
               .map(function (entry) {
@@ -2204,11 +2209,12 @@
                   return null;
                 }
                 var timestamps = lines[1].split(/\s*-->\s*/);
+                var text = strip(lines.slice(2).join("\n").replace(/\{\\an[0-9]{1,2}\}/g, ''));
                 return {
                   id: lines[0],
                   startTime: getSeconds(timestamps[0]),
                   endTime: getSeconds(timestamps[1]),
-                  text: lines.slice(2).join("\n").replace(/\{\\an[0-9]{1,2}\}/g, ''),
+                  text: text,
                 };
               })
               .filter(function (caption) {


### PR DESCRIPTION
I've been investigating an issue where animebook fails to create multi-line cards. It turned out to be caused by srt captions that have [HTML-like formatting](https://en.wikipedia.org/wiki/SubRip#Formatting). This PR just strips all HTML from the lines. I don't know how common is formatting in srt files, but I've found about this issue with a file a friend sent to me, which has weird `<font path="path_to_font">` tags (generated by some software).

The stripping function is copied from https://stackoverflow.com/a/47140708