### PR TITLE
Added hide parenthesis feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -834,6 +834,7 @@
                 <div class="table-row"><div class="table-cell">v</div><div class="table-cell">Toggle subtitle visibility on/off</div></div>
                 <div class="table-row"><div class="table-cell">c</div><div class="table-cell">Copy current subtitle text to clipboard</div></div>
                 <div class="table-row"><div class="table-cell">s</div><div class="table-cell">Copy screenshot of video to clipboard</div></div>
+                <div class="table-row"><div class="table-cell">[</div><div class="table-cell">Toggle visibility of parenthesis and text within parenthesis</div></div>
                 <div class="table-row"><div class="table-cell">/</div><div class="table-cell">Move video to the middle of the current caption and take a screenshot. Hold 'Shift' to move only.</div></div>
                 <div class="table-row"><div class="table-cell">,</div><div class="table-cell">Move video to the middle of the previous caption and take a screenshot. Hold 'Shift' to move only.</div></div>
                 <div class="table-row"><div class="table-cell">.</div><div class="table-cell">Move video to the middle of the next caption and take a screenshot. Hold 'Shift' to move only.</div></div>
@@ -1326,6 +1327,10 @@
                 stopEvent(e);
                 self.copyImage();
                 break;
+              case '[':
+                stopEvent(e);
+                self.hideParenthesis();
+                break;
               case 'c':
                 if (e.ctrlKey || e.altKey || e.metaKey)
                   return;
@@ -1711,6 +1716,20 @@
               window.getSelection().removeAllRanges();
             else if (document.selection)
               document.selection.empty();
+          },
+
+          hideParenthesis: function () {
+            let captions = this.fileToCaptions(this.subtitlesFileContent, this.subtitlesOffsetSeconds, this.customOffsets);
+
+            if (this.hideParenthesisToggle === !true || this.hideParenthesisToggle === undefined) {
+              for (let index = 0; index < captions.length; index++) {
+                this.captions[index].text = captions[index].text.replace(/[(]([^)]*)[)]/g, '');
+              }
+              this.hideParenthesisToggle = true;
+            } else {
+              this.captions = captions;
+              this.hideParenthesisToggle = false;
+            }
           },
 
           playPause: function (e) {


### PR DESCRIPTION
Responding to feature request #47 I added the functionality to toggle hide/show parenthesis and the contents within those parenthesis in form of a hotkey

<img width="1097" alt="Screenshot 2022-08-08 at 12 30 20 pm" src="https://user-images.githubusercontent.com/56118464/183410402-25796bbd-8f0c-418e-a3eb-4525d6ede42d.png">
<img width="1792" alt="Screenshot 2022-08-08 at 12 30 39 pm" src="https://user-images.githubusercontent.com/56118464/183410415-ac5b3944-e9de-4df7-8521-4bcef42edd65.png">
<img width="1791" alt="Screenshot 2022-08-08 at 12 30 48 pm" src="https://user-images.githubusercontent.com/56118464/183410439-ef616fa4-60db-4e31-b47a-7fcc37c5aaac.png">

