### PR TITLE
Custom subtitle styling

### DIFF
--- a/extension/fg/frontend.js
+++ b/extension/fg/frontend.js
@@ -98,22 +98,24 @@ function onHTMLMutation(mutationsList, cardCreator) {
 };
 
 function handleKeyDown(e, cardCreator) {
-    switch (e.key) {
-        case 'e':
-        case 'E':
-            if (e.ctrlKey || e.altKey || e.metaKey)
-                return;
-            const caption = document.querySelector('.caption.active');
-            if (!caption || !caption.getAttribute('data-caption-id'))
-                return;
+    if (document.activeElement !== document.getElementById("custom-style-box")) { // Check if custom style textarea is in focus
+        switch (e.key) {
+            case 'e':
+            case 'E':
+                if (e.ctrlKey || e.altKey || e.metaKey)
+                    return;
+                const caption = document.querySelector('.caption.active');
+                if (!caption || !caption.getAttribute('data-caption-id'))
+                    return;
 
-            const selectionRange = cardCreator.findSelectionRange(window.getSelection());
-            const start = (selectionRange && selectionRange.length > 0) ? selectionRange[0] : caption;
-            const id = start.getAttribute('data-caption-id');
-            cardCreator.addCard(id);
-            break;
-        default:
-            break;
+                const selectionRange = cardCreator.findSelectionRange(window.getSelection());
+                const start = (selectionRange && selectionRange.length > 0) ? selectionRange[0] : caption;
+                const id = start.getAttribute('data-caption-id');
+                cardCreator.addCard(id);
+                break;
+            default:
+                break;
+        }
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -862,8 +862,7 @@
                 default
               />
             </video>
-
-            <span class="current-caption" :style="'font-size: calc(' + (3.5 * savedSettings.subtitleFontSize) + 'vmin + 1.50rem);'" :key="shownCaptionsKey" lang="ja" v-html="displayedHtml"></span>
+              <span class="current-caption" :style="'font-size: calc(' + (3.5 * savedSettings.subtitleFontSize) + 'vmin + 1.50rem);' + savedSettings.subtitleStyling" :key="shownCaptionsKey" lang="ja" v-html="displayedHtml"></span>
           </div>
           <span id="ab-meta-data" style="display: none;" :data-audio-track="selectedAudioTrack || 0"></span>
           <div id="resize-bar-wrapper" class="resize-bar-wrapper" lang="ja">
@@ -951,6 +950,15 @@
                 <h3 style="margin-bottom: 0.1rem;">Subtitle font size</h3>
                 <input style="width: 30%;" type="range" min="0.1" max="3.0" step="0.1" id="subtitle-font-size" v-model.number="savedSettings.subtitleFontSize">
                 <label for="subtitle-font-size">{{(this.savedSettings.subtitleFontSize * 100).toFixed(0)}}%</label>
+              </p>
+              <p>
+                <h3 style="margin-bottom: 0.1rem;">Subtitle styling</h3>
+                <div style="margin-left: 1rem;">
+                  <p>
+                    Apply custom inline styles to the subtitles, such as fonts.
+                  </p>
+                  <textarea name="" id="custom-style-box" spellcheck="false" v-model="savedSettings.subtitleStyling" placeholder="e.g. font-family: Arial;" style="height: 100px; width: 100%; resize: none;"></textarea>
+                </div>
               </p>
               <p>
                 <h3 style="margin-bottom: 0.1rem;">Hide text matching regex</h4>
@@ -1246,6 +1254,7 @@
             videoAlignment: 'top',
             showVideoControls: true,
             subtitleFontSize: 1.0,
+            subtitleStyling: '',
             regexReplacements: [
               { regex: '\\(\\(.*?\\)\\)', replaceText: ''},
               { regex: '\\(.*?\\)', replaceText: ''},


### PR DESCRIPTION
Simple code that adds a setting in the Appearance tab to apply custom CSS to subtitles.
Changes are saved and applied instantly.
Doesn't seem to be any conflict with pre-existing styles.

The only caveat I've found is the Animebook Anki Export extension will trigger if I press the E key while focusing in the text box. This issue doesn't seem to happen with the other shortcuts.
A very simple workaround for this has been applied in frontend.js

Example:
<img width="1440" alt="example" src="https://user-images.githubusercontent.com/102995517/223874723-92c31662-deaf-41f8-be3c-4852f5d250a2.png">
